### PR TITLE
Convert Flask site to static GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # PabloNunes.github.io
-A short site for portfolio
+
+A simple portfolio site ready to be served with **GitHub Pages**. All content is static HTML, CSS and JavaScript.
+
+## Local preview
+
+1. Start a small HTTP server (Python 3):
+   ```bash
+   python -m http.server
+   ```
+2. Open your browser at `http://localhost:8000`.
+
+## Tests
+
+Run unit tests with:
+
+```bash
+pytest -q
+```

--- a/index.html
+++ b/index.html
@@ -1,10 +1,15 @@
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Página em construção</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Portfolio</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="static/css/styles.css">
 </head>
-<body>
-    <h1>Em construção...</h1>
+<body class="bg-light">
+    <div class="container py-4" id="blocks-container"></div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="static/js/app.js"></script>
 </body>
 </html>

--- a/static/blocks.json
+++ b/static/blocks.json
@@ -1,0 +1,8 @@
+[
+    {"name": "Introduction", "content": "Brief introduction text and a profile picture."},
+    {"name": "AboutMe", "content": "Detailed description of skills, experience, and personal details."},
+    {"name": "Projects", "content": "Showcase of featured projects with clickable cards."},
+    {"name": "Skills", "content": "Icons and brief descriptions of core skills."},
+    {"name": "Testimonials", "content": "Feedback from clients or colleagues to enhance credibility."},
+    {"name": "Contact", "content": "Form and social media links for contact."}
+]

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,0 +1,11 @@
+.block {
+    border-radius: 8px;
+    transition: box-shadow 0.3s;
+}
+.block.click-highlight {
+    box-shadow: 0 0 0 3px #0078D4 inset;
+}
+.high-contrast .block {
+    background-color: black;
+    color: white;
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,63 @@
+// Load blocks from JSON and render them
+function loadBlocks() {
+    fetch('static/blocks.json')
+        .then(response => response.json())
+        .then(blocks => {
+            const container = document.getElementById('blocks-container');
+            blocks.forEach(block => {
+                const div = document.createElement('div');
+                div.className = 'block mb-4 p-4 bg-white rounded shadow-sm';
+                div.setAttribute('tabindex', '0');
+                div.setAttribute('aria-label', block.name);
+
+                const h2 = document.createElement('h2');
+                h2.className = 'h4';
+                h2.textContent = block.name;
+                const p = document.createElement('p');
+                p.textContent = block.content;
+
+                div.appendChild(h2);
+                div.appendChild(p);
+                container.appendChild(div);
+            });
+            addClickHighlights();
+        })
+        .catch(err => console.error('Failed to load blocks:', err));
+}
+
+function addClickHighlights() {
+    const blocks = document.querySelectorAll('.block');
+    blocks.forEach(block => {
+        block.addEventListener('click', () => {
+            block.classList.add('click-highlight');
+            setTimeout(() => block.classList.remove('click-highlight'), 300);
+        });
+    });
+}
+
+function setupScrolling() {
+    const sensitivity = 1.5; // medium sensitivity
+    window.addEventListener('wheel', function(e) {
+        if (!e.ctrlKey) {
+            e.preventDefault();
+            window.scrollBy({
+                top: e.deltaY * sensitivity,
+                behavior: 'smooth'
+            });
+        }
+    }, {passive: false});
+}
+
+function setupHighContrastToggle() {
+    document.addEventListener('keydown', (e) => {
+        if (e.key.toLowerCase() === 'h') {
+            document.body.classList.toggle('high-contrast');
+        }
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    loadBlocks();
+    setupScrolling();
+    setupHighContrastToggle();
+});

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_blocks_json_valid():
+    data = json.loads((ROOT / 'static' / 'blocks.json').read_text())
+    assert isinstance(data, list)
+    assert any(block.get('name') == 'Projects' for block in data)
+
+
+def test_index_contains_container():
+    html = (ROOT / 'index.html').read_text()
+    assert re.search(r'id="blocks-container"', html)


### PR DESCRIPTION
## Summary
- drop Flask backend and switch to static HTML/JS
- render blocks from `static/blocks.json`
- add new JavaScript to load blocks and preserve interactivity
- update README with GitHub Pages instructions
- replace tests with static checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ca17f0e44832081364392dd12c3ed